### PR TITLE
Add EndOfCheckPhase processor

### DIFF
--- a/Onyx10.14/Onyx10.14.download.recipe
+++ b/Onyx10.14/Onyx10.14.download.recipe
@@ -30,6 +30,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The EndOfCheckPhase processor allows administrators to use `autopkg run --check`, which is typically used to check for newly available software versions but not process any subsequent steps. It's typical to include the EndOfCheckPhase processor in most .download recipes.