### PR TITLE
Affinity: Added CodesignatureVerifier

### DIFF
--- a/Affinity/Affinity.download.recipe
+++ b/Affinity/Affinity.download.recipe
@@ -30,6 +30,17 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Affinity.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.canva.affinity" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5HD2ARTBFS")</string>
+            </dict>
+        </dict>
 		<dict>
         <key>Processor</key>
         <string>AppDmgVersioner</string>


### PR DESCRIPTION
Hi @Darkomen78,

This PR adds the CodeSignatureVerifier step to the download recipe.

Please see the output of `autopkg run -vvq Affinity.download.recipe`:
```
Processing Affinity/Affinity.download.recipe...
WARNING: Affinity/Affinity.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Affinity.dmg',
           'url': 'https://downloads.affinity.studio/Affinity.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ladmin/Library/AutoPkg/Cache/com.github.darkomen78.download.Affinity/downloads/Affinity.dmg
{'Output': {'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.darkomen78.download.Affinity/downloads/Affinity.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.darkomen78.download.Affinity/downloads/Affinity.dmg/Affinity.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.canva.affinity" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5HD2ARTBFS")'}}
CodeSignatureVerifier: Mounted disk image /Users/ladmin/Library/AutoPkg/Cache/com.github.darkomen78.download.Affinity/downloads/Affinity.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.IvsPzA/Affinity.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.IvsPzA/Affinity.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.IvsPzA/Affinity.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.darkomen78.download.Affinity/downloads/Affinity.dmg'}}
AppDmgVersioner: Mounted disk image /Users/ladmin/Library/AutoPkg/Cache/com.github.darkomen78.download.Affinity/downloads/Affinity.dmg
AppDmgVersioner: BundleID: com.canva.affinity
AppDmgVersioner: Version: 3.0.1
{'Output': {'app_name': 'Affinity.app',
            'bundleid': 'com.canva.affinity',
            'version': '3.0.1'}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.darkomen78.download.Affinity/receipts/Affinity.download-receipt-20251126-151636.plist
```